### PR TITLE
Amend .h5p-ignore

### DIFF
--- a/.h5pignore
+++ b/.h5pignore
@@ -21,3 +21,7 @@ package.json
 package-lock.json
 worknotes
 LICENSE
+entries
+libraries
+scripts
+temp


### PR DESCRIPTION
When merged in, will amend `.h5pignore`, so H5P CLI will not pack source files into the distribution files.